### PR TITLE
Replace the outdated SAP list

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,5 +71,8 @@
 - [Telegram Apps Center](https://hackenproof.com/programs/telegram-apps-center)
 - [STON.fi DEX Smart Contracts v2](https://hackenproof.com/programs/ston-dot-fi-dex-smart-contracts-v2)
 
-## Security Assurance Providers(SAP)
-- https://docs.ton.org/develop/companies/auditors
+## Auditors
+- [TON Talent Directory](https://ton.org/en/talents)
+  - [Agencies](https://ton.org/en/talents?Agency) – small companies and teams in the ecosystem, including auditors
+  - [Auditors](https://ton.org/en/talents?Auditors) – established security firms
+- [ton.app: Smart Contract Audit](https://ton.app/audit) – moderated, community-driven auditors list


### PR DESCRIPTION
According to https://docs.ton.org/v3/concepts/qa-outsource/auditors, that page is outdated:

![](https://github.com/user-attachments/assets/fbb39f2b-ed46-46db-80c7-62a6336165ea)

I suggest replacing it with [ton.org/auditor](https://ton.org/talents?filterBy=Auditors), which has two sections:  
- *Agencies* – a community-driven list moderated by TF, containing small companies/teams working in the ecosystem.  
- *Auditors* – added by TF, featuring large, well-known security companies.  

I also suggest adding [ton.app/audit](https://ton.app/audit) as it provides another community-driven list of TON auditors.  